### PR TITLE
A.Trigger remap for MiSTer inputs

### DIFF
--- a/cores/outrun/hdl/jtoutrun_main.v
+++ b/cores/outrun/hdl/jtoutrun_main.v
@@ -317,8 +317,9 @@ always @(*) begin
                     // Brake ADC
                     2: begin
                         case( ctrl_type )
-                            0,1: cab_dout = dacana1b[15] ?  8'd0 : {dacana1b[14:8], dacana1b[14]};     // brake pedal dual analog stick/analog trigger
-                            2:   cab_dout = dacana1b[15] ? ~{dacana1b[14:8], dacana1b[14]} : 8'd0;     // brake logictech steering wheel
+                            0: cab_dout = dacana1b[15] ?  8'd0 : {dacana1b[14:8], dacana1b[14]};     // brake pedal dual analog stick
+                            1: cab_dout = dacana1[ 15] ?  8'd0 : {dacana1[14:8],   dacana1[14]};     // brake pedal analog trigger
+                            2: cab_dout = dacana1b[15] ? ~{dacana1b[14:8], dacana1b[14]} : 8'd0;     // brake logictech steering wheel
                             default: cab_dout = 0;
                         endcase
                         if( !joystick1[5] ) cab_dout = 8'hff;
@@ -366,8 +367,9 @@ always @(*) begin
                     // Brake ADC
                     2: begin
                         case( ctrl_type )
-                            0,1: cab_dout = dacana1b[15] ?  8'd0 : {dacana1b[14:8], dacana1b[14]};     // brake pedal dual analog stick/analog trigger
-                            2:   cab_dout = dacana1b[15] ? ~{dacana1b[14:8], dacana1b[14]} : 8'd0;     // brake logictech steering wheel
+                            0: cab_dout = dacana1b[15] ?  8'd0 : {dacana1b[14:8], dacana1b[14]};     // brake pedal dual analog stick
+                            1: cab_dout = dacana1[ 15] ?  8'd0 : {dacana1[14:8],   dacana1[14]};     // brake pedal analog trigger   
+                            2: cab_dout = dacana1b[15] ? ~{dacana1b[14:8], dacana1b[14]} : 8'd0;     // brake logictech steering wheel
                             default: cab_dout = 0;
                         endcase
                         if( !joystick1[5] ) cab_dout = 8'hff;


### PR DESCRIPTION
Simplify mapping of left analog trigger to left thumb stick "down" in MiSTer mapping and right analog trigger to right thumb stick "right". 

This is modified due to no third axis mapping for MiSTer inputs with compatible controllers. Applies to both shangon and outrun / toutrun.