### PR TITLE
Connect reset output from main cpu (CRESET)

### DIFF
--- a/cores/outrun/hdl/jtoutrun_game.v
+++ b/cores/outrun/hdl/jtoutrun_game.v
@@ -134,6 +134,7 @@ wire [19:0] obj_addr;
 wire [15:0] obj_data;
 
 // CPU interface
+wire        creset;
 wire [15:0] main_dout, char_dout, pal_dout, obj_dout;
 wire [ 1:0] main_dsn, main_dswn;
 wire        main_rnw, sub_br,
@@ -243,6 +244,7 @@ jtoutrun_main u_main(
     .sub_cs      ( sub_br     ),
     .sub_ok      ( sub_ok     ),
     .sub_din     ( sub_din    ),
+    .creset      ( creset     ),
     // cabinet I/O
     .ctrl_type   ( ctrl_type  ),
     .joystick1   ( joystick1  ),
@@ -308,6 +310,7 @@ jtoutrun_main u_main(
 `ifndef NOSUB
 jtoutrun_sub u_sub(
     .rst        ( rst       ),
+    .creset     ( creset    ),
     .clk        ( clk       ),
 
     .irqn       ( ~vint     ),    // common with main CPU

--- a/cores/outrun/hdl/jtoutrun_main.v
+++ b/cores/outrun/hdl/jtoutrun_main.v
@@ -56,6 +56,7 @@ module jtoutrun_main(
     input              sub_ok,
     input       [15:0] sub_din,
     output      [ 1:0] dsn,
+    output             creset,
 
     // cabinet I/O
     input       [ 2:0] ctrl_type,
@@ -133,7 +134,7 @@ wire        DTACKn, cpu_vpan;
 
 wire bus_cs    = pal_cs | char_cs | vram_cs | ram_cs | rom_cs | objram_cs | io_cs | sub_cs;
 wire bus_busy  = |{ rom_cs & ~dec_ok, (ram_cs | vram_cs) & ~ram_ok, sub_cs & ~sub_ok };
-wire cpu_rst, cpu_haltn, cpu_asn;
+wire cpu_rst, cpu_haltn, cpu_asn, cpu_oresetn;
 wire [ 1:0] cpu_dsn;
 reg  [15:0] cpu_din, dacana1, dacana1b;
 wire [15:0] mapper_dout, motor_pos;
@@ -148,6 +149,7 @@ assign LDSWn = RnW | LDSn;
 assign flip     = 0;
 assign addr     = A[19:1];
 assign mix_ipln = { cpu_ipln[2], line_intn, 1'b1 };
+assign creset = cpu_rst | ~cpu_oresetn;
 
 jts16b_mapper u_mapper(
     .rst        ( rst            ),
@@ -527,6 +529,7 @@ jtframe_m68k u_cpu(
     .FC         ( FC          ),
 
     .BERRn      ( BERRn       ),
+    .RESETn     ( cpu_oresetn ),
     // Bus arbitrion
     .HALTn      ( cpu_haltn   ),
     .BRn        ( BRn         ),

--- a/cores/outrun/hdl/jtoutrun_sub.v
+++ b/cores/outrun/hdl/jtoutrun_sub.v
@@ -18,6 +18,7 @@
 
 module jtoutrun_sub(
     input              rst,
+    input              creset,
     input              clk,
 
     input              irqn,    // common with main CPU
@@ -164,7 +165,7 @@ jtframe_68kdma u_dma(
 
 jtframe_m68k u_cpu(
     .clk        ( clk         ),
-    .rst        ( rst         ),
+    .rst        ( rst | creset),
     .cpu_cen    ( cpu_cen     ),
     .cpu_cenb   ( cpu_cenb    ),
 
@@ -183,7 +184,7 @@ jtframe_m68k u_cpu(
 
     .BERRn      ( 1'b1        ),
     // Bus arbitrion
-    .HALTn      ( 1'b1        ),
+    .HALTn      ( ~creset     ),
     .BRn        ( BRn         ),
     .BGACKn     ( BGACKn      ),
     .BGn        ( BGn         ),


### PR DESCRIPTION
Allow the game to start (the main CPU resets the sub CPU after some initialization is done in the shared memory).